### PR TITLE
Updated script decorator

### DIFF
--- a/lib/create-script-decorator.ts
+++ b/lib/create-script-decorator.ts
@@ -45,6 +45,7 @@ export class ScriptTypeBase {
      * @type {pc.Application}
      * @memberof ScriptType
      */
+    // @ts-ignore
     app: pc.Application;
 
     /**
@@ -52,6 +53,7 @@ export class ScriptTypeBase {
      * @type {pc.Entity}
      * @memberof ScriptType
      */
+    // @ts-ignore
     entity: pc.Entity;
 
     /**
@@ -59,5 +61,6 @@ export class ScriptTypeBase {
      * @type {boolean}
      * @memberof ScriptType
      */
+    // @ts-ignore
     enabled: boolean;    
 }


### PR DESCRIPTION
In the latest version of typescript, an error is thrown when strict checking is enabled and a property is not initialized in the constructor of a class